### PR TITLE
Preserving dtype for numpy.float32 in Least Angle Regression

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,13 +26,13 @@
 .. |DOI| image:: https://zenodo.org/badge/21369/scikit-learn/scikit-learn.svg
 .. _DOI: https://zenodo.org/badge/latestdoi/21369/scikit-learn/scikit-learn
 
-.. |PythonMinVersion| replace:: 3.6
-.. |NumPyMinVersion| replace:: 1.13.3
-.. |SciPyMinVersion| replace:: 0.19.1
+.. |PythonMinVersion| replace:: 3.7
+.. |NumPyMinVersion| replace:: 1.14.5
+.. |SciPyMinVersion| replace:: 1.1.0
 .. |JoblibMinVersion| replace:: 0.11
 .. |ThreadpoolctlMinVersion| replace:: 2.0.0
-.. |MatplotlibMinVersion| replace:: 2.1.1
-.. |Scikit-ImageMinVersion| replace:: 0.13
+.. |MatplotlibMinVersion| replace:: 2.2.2
+.. |Scikit-ImageMinVersion| replace:: 0.14.5
 .. |PandasMinVersion| replace:: 0.25.0
 .. |SeabornMinVersion| replace:: 0.9.0
 .. |PytestMinVersion| replace:: 5.0.1
@@ -70,6 +70,7 @@ scikit-learn requires:
 
 **Scikit-learn 0.20 was the last version to support Python 2.7 and Python 3.4.**
 scikit-learn 0.23 and later require Python 3.6 or newer.
+scikit-learn 1.0 and later require Python 3.7 or newer.
 
 Scikit-learn plotting capabilities (i.e., functions start with ``plot_`` and
 classes end with "Display") require Matplotlib (>= |MatplotlibMinVersion|).

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -142,7 +142,8 @@ purpose.
     Scikit-learn 0.20 was the last version to support Python 2.7 and Python 3.4.
     Scikit-learn 0.21 supported Python 3.5-3.7.
     Scikit-learn 0.22 supported Python 3.5-3.8.
-    Scikit-learn now requires Python 3.6 or newer.
+    Scikit-learn 0.23 - 0.24 require Python 3.6 or newer.
+    Scikit-learn 1.0 and later requires Python 3.7 or newer.
 
 
 .. note::

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -150,6 +150,11 @@ Changelog
 - |Efficiency| :class:`cluster.MiniBatchKMeans` is now faster in multicore
   settings. :pr:`17622` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+- |Enhancement| The `predict` and `fit_predict` methods of
+  :class:`cluster.AffinityPropagation` now accept sparse data type for input
+  data.
+  :pr:`20117` by :user:`Venkatachalam Natchiappan <venkyyuvy>`
+
 - |Fix| Fixed a bug in :class:`cluster.MiniBatchKMeans` where the sample
   weights were partially ignored when the input is sparse. :pr:`17622` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -339,6 +339,10 @@ Changelog
   is now faster. This is especially noticeable on large sparse input.
   :pr:`19734` by :user:`Fred Robinson <frrad>`.
 
+- |Enhancement| `fit` method preserves dtype for numpy.float32 in
+  :class:`Lars`, :class:`LassoLars`, :class:`LassoLars`, :class:`LarsCV` and :class:`LassoLarsCV`.
+  :pr:`20155` by :user:`Takeshi Oura <takoika>`.
+
 :mod:`sklearn.manifold`
 .......................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -340,8 +340,8 @@ Changelog
   :pr:`19734` by :user:`Fred Robinson <frrad>`.
 
 - |Enhancement| `fit` method preserves dtype for numpy.float32 in
-  :class:`Lars`, :class:`LassoLars`, :class:`LassoLars`, :class:`LarsCV` and :class:`LassoLarsCV`.
-  :pr:`20155` by :user:`Takeshi Oura <takoika>`.
+  :class:`Lars`, :class:`LassoLars`, :class:`LassoLars`, :class:`LarsCV` and
+  :class:`LassoLarsCV`. :pr:`20155` by :user:`Takeshi Oura <takoika>`.
 
 :mod:`sklearn.manifold`
 .......................

--- a/examples/ensemble/plot_forest_importances_faces.py
+++ b/examples/ensemble/plot_forest_importances_faces.py
@@ -3,46 +3,89 @@
 Pixel importances with a parallel forest of trees
 =================================================
 
-This example shows the use of forests of trees to evaluate the impurity-based
-importance of the pixels in an image classification task (faces).
-The hotter the pixel, the more important.
+This example shows the use of a forest of trees to evaluate the impurity
+based importance of the pixels in an image classification task on the faces
+dataset. The hotter the pixel, the more important it is.
 
 The code below also illustrates how the construction and the computation
 of the predictions can be parallelized within multiple jobs.
 """
+# %%
 print(__doc__)
 
-from time import time
-import matplotlib.pyplot as plt
-
+# %%
+# Loading the data and model fitting
+# ----------------------------------
+# First, we load the olivetti faces dataset and limit the dataset to contain
+# only the first five classes. Then we train a random forest on the dataset
+# and evaluate the impurity-based feature importance. One drawback of this
+# method is that it cannot be evaluated on a separate test set. For this
+# example, we are interested in representing the information learned from
+# the full dataset. Also, we'll set the number of cores to use for the tasks.
 from sklearn.datasets import fetch_olivetti_faces
-from sklearn.ensemble import ExtraTreesClassifier
 
-# Number of cores to use to perform parallel fitting of the forest model
-n_jobs = 1
+# %%
+# We select the number of cores to use to perform parallel fitting of
+# the forest model. `-1` means use all available cores.
+n_jobs = -1
 
+# %%
 # Load the faces dataset
 data = fetch_olivetti_faces()
 X, y = data.data, data.target
 
-mask = y < 5  # Limit to 5 classes
+# %%
+# Limit the dataset to 5 classes.
+mask = y < 5
 X = X[mask]
 y = y[mask]
 
-# Build a forest and compute the pixel importances
-print("Fitting ExtraTreesClassifier on faces data with %d cores..." % n_jobs)
-t0 = time()
-forest = ExtraTreesClassifier(n_estimators=1000,
-                              max_features=128,
-                              n_jobs=n_jobs,
-                              random_state=0)
+# %%
+# A random forest classifier will be fitted to compute the feature importances.
+from sklearn.ensemble import RandomForestClassifier
+
+forest = RandomForestClassifier(
+    n_estimators=750, n_jobs=n_jobs, random_state=42)
 
 forest.fit(X, y)
-print("done in %0.3fs" % (time() - t0))
-importances = forest.feature_importances_
-importances = importances.reshape(data.images[0].shape)
 
-# Plot pixel importances
-plt.matshow(importances, cmap=plt.cm.hot)
-plt.title("Pixel importances with forests of trees")
+# %%
+# Feature importance based on mean decrease in impurity (MDI)
+# -----------------------------------------------------------
+# Feature importances are provided by the fitted attribute
+# `feature_importances_` and they are computed as the mean and standard
+# deviation of accumulation of the impurity decrease within each tree.
+#
+# .. warning::
+#     Impurity-based feature importances can be misleading for high cardinality
+#     features (many unique values). See :ref:`permutation_importance` as
+#     an alternative.
+import time
+import matplotlib.pyplot as plt
+
+start_time = time.time()
+img_shape = data.images[0].shape
+importances = forest.feature_importances_
+elapsed_time = time.time() - start_time
+
+print(f"Elapsed time to compute the importances: "
+      f"{elapsed_time:.3f} seconds")
+imp_reshaped = importances.reshape(img_shape)
+plt.matshow(imp_reshaped, cmap=plt.cm.hot)
+plt.title("Pixel importances using impurity values")
+plt.colorbar()
 plt.show()
+
+# %%
+# Can you still recognize a face?
+
+# %%
+# The limitations of MDI is not a problem for this dataset because:
+#
+#  1. All features are (ordered) numeric and will thus not suffer the
+#     cardinality bias
+#  2. We are only interested to represent knowledge of the forest acquired
+#     on the training set.
+#
+# If these two conditions are not met, it is recommended to instead use
+# the :func:`~sklearn.inspection.permutation_importance`.

--- a/examples/model_selection/plot_nested_cross_validation_iris.py
+++ b/examples/model_selection/plot_nested_cross_validation_iris.py
@@ -80,11 +80,12 @@ for i in range(NUM_TRIALS):
     outer_cv = KFold(n_splits=4, shuffle=True, random_state=i)
 
     # Non_nested parameter search and scoring
-    clf = GridSearchCV(estimator=svm, param_grid=p_grid, cv=inner_cv)
+    clf = GridSearchCV(estimator=svm, param_grid=p_grid, cv=outer_cv)
     clf.fit(X_iris, y_iris)
     non_nested_scores[i] = clf.best_score_
 
     # Nested CV with parameter optimization
+    clf = GridSearchCV(estimator=svm, param_grid=p_grid, cv=inner_cv)
     nested_score = cross_val_score(clf, X=X_iris, y=y_iris, cv=outer_cv)
     nested_scores[i] = nested_score.mean()
 

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -436,7 +436,7 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
             Cluster labels.
         """
         check_is_fitted(self)
-        X = self._validate_data(X, reset=False)
+        X = self._validate_data(X, reset=False, accept_sparse='csr')
         if not hasattr(self, "cluster_centers_"):
             raise ValueError("Predict method is not supported when "
                              "affinity='precomputed'.")

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -197,11 +197,18 @@ def spectral_clustering(affinity, *, n_clusters=8, n_components=None,
         used.
 
     random_state : int, RandomState instance, default=None
-        A pseudo random number generator used for the initialization of the
-        lobpcg eigenvectors decomposition when eigen_solver == 'amg' and by
-        the K-Means initialization. Use an int to make the randomness
-        deterministic.
-        See :term:`Glossary <random_state>`.
+        A pseudo random number generator used for the initialization
+        of the lobpcg eigenvectors decomposition when `eigen_solver ==
+        'amg'`, and for the K-Means initialization. Use an int to make
+        the results deterministic across calls (See
+        :term:`Glossary <random_state>`).
+
+        .. note::
+            When using `eigen_solver == 'amg'`,
+            it is necessary to also fix the global numpy seed with
+            `np.random.seed(int)` to get deterministic results. See
+            https://github.com/pyamg/pyamg/issues/139 for further
+            information.
 
     n_init : int, default=10
         Number of time the k-means algorithm will be run with different
@@ -322,11 +329,18 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
         Number of eigenvectors to use for the spectral embedding
 
     random_state : int, RandomState instance, default=None
-        A pseudo random number generator used for the initialization of the
-        lobpcg eigenvectors decomposition when ``eigen_solver='amg'`` and by
-        the K-Means initialization. Use an int to make the randomness
-        deterministic.
-        See :term:`Glossary <random_state>`.
+        A pseudo random number generator used for the initialization
+        of the lobpcg eigenvectors decomposition when `eigen_solver ==
+        'amg'`, and for the K-Means initialization. Use an int to make
+        the results deterministic across calls (See
+        :term:`Glossary <random_state>`).
+
+        .. note::
+            When using `eigen_solver == 'amg'`,
+            it is necessary to also fix the global numpy seed with
+            `np.random.seed(int)` to get deterministic results. See
+            https://github.com/pyamg/pyamg/issues/139 for further
+            information.
 
     n_init : int, default=10
         Number of time the k-means algorithm will be run with different

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -238,6 +238,25 @@ def test_affinity_propagation_float32():
     assert_array_equal(afp.labels_, expected)
 
 
+def test_sparse_input_for_predict():
+    # Test to make sure sparse inputs are accepted for predict
+    # (non-regression test for issue #20049)
+    af = AffinityPropagation(affinity="euclidean", random_state=42)
+    af.fit(X)
+    labels = af.predict(csr_matrix((2, 2)))
+    assert_array_equal(labels, (2, 2))
+
+
+def test_sparse_input_for_fit_predict():
+    # Test to make sure sparse inputs are accepted for fit_predict
+    # (non-regression test for issue #20049)
+    af = AffinityPropagation(affinity="euclidean", random_state=42)
+    rng = np.random.RandomState(42)
+    X = csr_matrix(rng.randint(0, 2, size=(5, 5)))
+    labels = af.fit_predict(X)
+    assert_array_equal(labels, (0, 1, 1, 2, 3))
+
+
 # TODO: Remove in 1.1
 def test_affinity_propagation_pairwise_is_deprecated():
     afp = AffinityPropagation(affinity='precomputed')

--- a/sklearn/datasets/descr/california_housing.rst
+++ b/sklearn/datasets/descr/california_housing.rst
@@ -10,26 +10,32 @@ California Housing dataset
     :Number of Attributes: 8 numeric, predictive attributes and the target
 
     :Attribute Information:
-        - MedInc        median income in block
-        - HouseAge      median house age in block
-        - AveRooms      average number of rooms
-        - AveBedrms     average number of bedrooms
-        - Population    block population
-        - AveOccup      average house occupancy
-        - Latitude      house block latitude
-        - Longitude     house block longitude
+        - MedInc        median income in block group
+        - HouseAge      median house age in block group
+        - AveRooms      average number of rooms per household
+        - AveBedrms     average number of bedrooms per household
+        - Population    block group population
+        - AveOccup      average number of household members
+        - Latitude      block group latitude
+        - Longitude     block group longitude
 
     :Missing Attribute Values: None
 
 This dataset was obtained from the StatLib repository.
-http://lib.stat.cmu.edu/datasets/
+https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html
 
-The target variable is the median house value for California districts.
+The target variable is the median house value for California districts,
+expressed in hundreds of thousands of dollars ($100,000).
 
 This dataset was derived from the 1990 U.S. census, using one row per census
 block group. A block group is the smallest geographical unit for which the U.S.
 Census Bureau publishes sample data (a block group typically has a population
 of 600 to 3,000 people).
+
+An household is a group of people residing within a home. Since the average
+number of rooms and bedrooms in this dataset are provided per household, these
+columns may take surpinsingly large values for block groups with few households
+and many empty houses, such as vacation resorts.
 
 It can be downloaded/loaded using the
 :func:`sklearn.datasets.fetch_california_housing` function.

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -12,9 +12,7 @@ import pytest
 from sklearn.utils._testing import assert_almost_equal, _convert_container
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
-from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import ignore_warnings
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils import safe_mask
 
 from sklearn.datasets import make_classification, make_regression
@@ -271,8 +269,8 @@ def test_select_kbest_zero():
     support = univariate_filter.get_support()
     gtruth = np.zeros(10, dtype=bool)
     assert_array_equal(support, gtruth)
-    X_selected = assert_warns_message(UserWarning, 'No features were selected',
-                                      univariate_filter.transform, X)
+    with pytest.warns(UserWarning, match="No features were selected"):
+        X_selected = univariate_filter.transform(X)
     assert X_selected.shape == (20, 0)
 
 
@@ -620,7 +618,8 @@ def test_f_classif_constant_feature():
 
     X, y = make_classification(n_samples=10, n_features=5)
     X[:, 0] = 2.0
-    assert_warns(UserWarning, f_classif, X, y)
+    with pytest.warns(UserWarning):
+        f_classif(X, y)
 
 
 def test_no_feature_selected():
@@ -639,8 +638,8 @@ def test_no_feature_selected():
     ]
     for selector in strict_selectors:
         assert_array_equal(selector.get_support(), np.zeros(10))
-        X_selected = assert_warns_message(
-            UserWarning, 'No features were selected', selector.transform, X)
+        with pytest.warns(UserWarning, match="No features were selected"):
+            X_selected = selector.transform(X)
         assert X_selected.shape == (40, 0)
 
 

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -476,12 +476,21 @@ def _lars_path_solver(
 
     max_features = min(max_iter, n_features)
 
+    return_dtype = np.float64
+    for input_array in (X, y, Xy, Gram):
+        if input_array is not None:
+            return_dtype = input_array.dtype
+            break
+
     if return_path:
-        coefs = np.zeros((max_features + 1, n_features))
-        alphas = np.zeros(max_features + 1)
+        coefs = np.zeros((max_features + 1, n_features), dtype=return_dtype)
+        alphas = np.zeros(max_features + 1, dtype=return_dtype)
     else:
-        coef, prev_coef = np.zeros(n_features), np.zeros(n_features)
-        alpha, prev_alpha = np.array([0.]), np.array([0.])  # better ideas?
+        coef, prev_coef = (np.zeros(n_features, dtype=return_dtype),
+                           np.zeros(n_features, dtype=return_dtype))
+        alpha, prev_alpha = (np.array([0.], dtype=return_dtype),
+                             np.array([0.], dtype=return_dtype))
+        # above better ideas?
 
     n_iter, n_active = 0, 0
     active, indices = list(), np.arange(n_features)
@@ -948,7 +957,7 @@ class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
 
         self.alphas_ = []
         self.n_iter_ = []
-        self.coef_ = np.empty((n_targets, n_features))
+        self.coef_ = np.empty((n_targets, n_features), dtype=X.dtype)
 
         if fit_path:
             self.active_ = []

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -476,12 +476,15 @@ def _lars_path_solver(
 
     max_features = min(max_iter, n_features)
 
-    return_dtype = np.float64
-    for input_array in (X, y, Xy, Gram):
-        if input_array is not None:
-            return_dtype = input_array.dtype
-            break
+    dtypes = set(a.dtype for a in (X, y, Xy, Gram) if a is not None)
+    if len(dtypes) == 1:
+        # use the precision level of input data if it is consistent
+        return_dtype = next(iter(dtypes))
+    else:
+        # fallback to double precision otherwise
+        return_dtype = np.float64
 
+    print(dtypes, return_dtype)
     if return_path:
         coefs = np.zeros((max_features + 1, n_features), dtype=return_dtype)
         alphas = np.zeros(max_features + 1, dtype=return_dtype)

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -484,7 +484,6 @@ def _lars_path_solver(
         # fallback to double precision otherwise
         return_dtype = np.float64
 
-    print(dtypes, return_dtype)
     if return_path:
         coefs = np.zeros((max_features + 1, n_features), dtype=return_dtype)
         alphas = np.zeros(max_features + 1, dtype=return_dtype)

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1041,10 +1041,17 @@ class LogisticRegression(LinearClassifierMixin,
     Parameters
     ----------
     penalty : {'l1', 'l2', 'elasticnet', 'none'}, default='l2'
-        Used to specify the norm used in the penalization. The 'newton-cg',
-        'sag' and 'lbfgs' solvers support only l2 penalties. 'elasticnet' is
-        only supported by the 'saga' solver. If 'none' (not supported by the
-        liblinear solver), no regularization is applied.
+        Specify the norm of the penalty:
+
+        - `'none'`: no penalty is added;
+        - `'l2'`: add a L2 penalty term and it is the default choice;
+        - `'l1'`: add a L1 penalty term;
+        - `'elasticnet'`: both L1 and L2 penalty terms are added.
+
+        .. warning::
+           Some penalties may not work with some solvers. See the parameter
+           `solver` below, to know the compatibility between the penalty and
+           solver.
 
         .. versionadded:: 0.19
            l1 penalty with SAGA solver (allowing 'multinomial' + L1)
@@ -1100,21 +1107,38 @@ class LogisticRegression(LinearClassifierMixin,
     solver : {'newton-cg', 'lbfgs', 'liblinear', 'sag', 'saga'}, \
             default='lbfgs'
 
-        Algorithm to use in the optimization problem.
+        Algorithm to use in the optimization problem. Default is 'lbfgs'.
+        To choose a solver, you might want to consider the following aspects:
 
-        - For small datasets, 'liblinear' is a good choice, whereas 'sag' and
-          'saga' are faster for large ones.
-        - For multiclass problems, only 'newton-cg', 'sag', 'saga' and 'lbfgs'
-          handle multinomial loss; 'liblinear' is limited to one-versus-rest
-          schemes.
-        - 'newton-cg', 'lbfgs', 'sag' and 'saga' handle L2 or no penalty
-        - 'liblinear' and 'saga' also handle L1 penalty
-        - 'saga' also supports 'elasticnet' penalty
-        - 'liblinear' does not support setting ``penalty='none'``
+            - For small datasets, 'liblinear' is a good choice, whereas 'sag'
+              and 'saga' are faster for large ones;
+            - For multiclass problems, only 'newton-cg', 'sag', 'saga' and
+              'lbfgs' handle multinomial loss;
+            - 'liblinear' is limited to one-versus-rest schemes.
 
-        Note that 'sag' and 'saga' fast convergence is only guaranteed on
-        features with approximately the same scale. You can
-        preprocess the data with a scaler from sklearn.preprocessing.
+        .. warning::
+           The choice of the algorithm depends on the penalty chosen:
+           Supported penalties by solver:
+
+           - 'newton-cg'   -   ['l2', 'none']
+           - 'lbfgs'       -   ['l2', 'none']
+           - 'liblinear'   -   ['l1', 'l2']
+           - 'sag'         -   ['l2', 'none']
+           - 'saga'        -   ['elasticnet', 'l1', 'l2', 'none']
+
+        .. note::
+           'sag' and 'saga' fast convergence is only guaranteed on
+           features with approximately the same scale. You can
+           preprocess the data with a scaler from :mod:`sklearn.preprocessing`.
+
+        .. seealso::
+           Refer to the User Guide for more information regarding
+           :class:`LogisticRegression` and more specifically the
+           `Table <https://scikit-learn.org/dev/modules/linear_model.html#logistic-regression>`_
+           summarazing solver/penalty supports.
+           <!--
+           # noqa: E501
+           -->
 
         .. versionadded:: 0.17
            Stochastic Average Gradient descent solver.
@@ -1549,9 +1573,16 @@ class LogisticRegressionCV(LogisticRegression,
         n_samples > n_features.
 
     penalty : {'l1', 'l2', 'elasticnet'}, default='l2'
-        Used to specify the norm used in the penalization. The 'newton-cg',
-        'sag' and 'lbfgs' solvers support only l2 penalties. 'elasticnet' is
-        only supported by the 'saga' solver.
+        Specify the norm of the penalty:
+
+        - `'l2'`: add a L2 penalty term (used by default);
+        - `'l1'`: add a L1 penalty term;
+        - `'elasticnet'`: both L1 and L2 penalty terms are added.
+
+        .. warning::
+           Some penalties may not work with some solvers. See the parameter
+           `solver` below, to know the compatibility between the penalty and
+           solver.
 
     scoring : str or callable, default=None
         A string (see model evaluation documentation) or
@@ -1563,21 +1594,30 @@ class LogisticRegressionCV(LogisticRegression,
     solver : {'newton-cg', 'lbfgs', 'liblinear', 'sag', 'saga'}, \
             default='lbfgs'
 
-        Algorithm to use in the optimization problem.
+        Algorithm to use in the optimization problem. Default is 'lbfgs'.
+        To choose a solver, you might want to consider the following aspects:
 
-        - For small datasets, 'liblinear' is a good choice, whereas 'sag' and
-          'saga' are faster for large ones.
-        - For multiclass problems, only 'newton-cg', 'sag', 'saga' and 'lbfgs'
-          handle multinomial loss; 'liblinear' is limited to one-versus-rest
-          schemes.
-        - 'newton-cg', 'lbfgs' and 'sag' only handle L2 penalty, whereas
-          'liblinear' and 'saga' handle L1 penalty.
-        - 'liblinear' might be slower in LogisticRegressionCV because it does
-          not handle warm-starting.
+            - For small datasets, 'liblinear' is a good choice, whereas 'sag'
+              and 'saga' are faster for large ones;
+            - For multiclass problems, only 'newton-cg', 'sag', 'saga' and
+              'lbfgs' handle multinomial loss;
+            - 'liblinear' might be slower in :class:`LogisticRegressionCV`
+              because it does not handle warm-starting. 'liblinear' is
+              limited to one-versus-rest schemes.
 
-        Note that 'sag' and 'saga' fast convergence is only guaranteed on
-        features with approximately the same scale. You can preprocess the data
-        with a scaler from sklearn.preprocessing.
+        .. warning::
+           The choice of the algorithm depends on the penalty chosen:
+
+           - 'newton-cg'   -   ['l2']
+           - 'lbfgs'       -   ['l2']
+           - 'liblinear'   -   ['l1', 'l2']
+           - 'sag'         -   ['l2']
+           - 'saga'        -   ['elasticnet', 'l1', 'l2']
+
+        .. note::
+           'sag' and 'saga' fast convergence is only guaranteed on features
+           with approximately the same scale. You can preprocess the data with
+           a scaler from :mod:`sklearn.preprocessing`.
 
         .. versionadded:: 0.17
            Stochastic Average Gradient descent solver.

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -777,3 +777,14 @@ def test_copy_X_with_auto_gram():
     linear_model.lars_path(X, y, Gram='auto', copy_X=True, method='lasso')
     # X did not change
     assert_allclose(X, X_before)
+
+def test_lars_dtype_match():
+    rng = np.random.RandomState(0)
+    X = rng.rand(6, 6).astype(np.float32)
+    Y = rng.rand(6).astype(np.float32)
+
+    model = Lars(n_nonzero_coefs=1)
+    model.fit(X,Y)
+    assert model.coef_.dtype == np.float32
+    assert model.coef_path_.dtype == np.float32
+    assert model.intercept_.dtype == np.float32

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -786,15 +786,15 @@ def test_copy_X_with_auto_gram():
                           (LarsCV, True, {}),
                           # max_iter=5 is for avoiding ConvergenceWarning
                           (LassoLarsCV, True, {"max_iter": 5})))
-@pytest.mark.parametrize("x_data_type, y_data_type, expected_type", (
-    (np.float32, np.float32, np.float32),
-    (np.float64, np.float64, np.float64)))
+@pytest.mark.parametrize("data_type, expected_type", (
+    (np.float32, np.float32),
+    (np.float64, np.float64)))
 def test_lars_dtype_match(LARS, has_coef_path, args,
-                          x_data_type, y_data_type, expected_type):
+                          data_type, expected_type):
     # The test ensures that the fit method preserves input dtype
     rng = np.random.RandomState(0)
-    X = rng.rand(6, 6).astype(x_data_type)
-    y = rng.rand(6).astype(y_data_type)
+    X = rng.rand(6, 6).astype(data_type)
+    y = rng.rand(6).astype(data_type)
 
     model = LARS(**args)
     model.fit(X, y)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -811,6 +811,8 @@ def test_lars_dtype_match(LARS, has_coef_path, args,
                           # max_iter=5 is for avoiding ConvergenceWarning
                           (LassoLarsCV, True, {"max_iter": 5})))
 def test_lars_numeric_consistency(LARS, has_coef_path, args):
+    atol = 1e-6
+
     rng = np.random.RandomState(0)
     X_64 = rng.rand(6, 6)
     y_64 = rng.rand(6)
@@ -819,7 +821,7 @@ def test_lars_numeric_consistency(LARS, has_coef_path, args):
     model_32 = LARS(**args).fit(X_64.astype(np.float32),
                                 y_64.astype(np.float32))
 
-    assert_array_almost_equal(model_64.coef_, model_32.coef_)
+    assert_allclose(model_64.coef_, model_32.coef_, atol=atol)
     if has_coef_path:
-        assert_array_almost_equal(model_64.coef_path_, model_32.coef_path_)
-    assert_array_almost_equal(model_64.intercept_, model_32.intercept_)
+        assert_allclose(model_64.coef_path_, model_32.coef_path_, atol=atol)
+    assert_allclose(model_64.intercept_, model_32.intercept_, atol=atol)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -778,6 +778,7 @@ def test_copy_X_with_auto_gram():
     # X did not change
     assert_allclose(X, X_before)
 
+
 @pytest.mark.parametrize("LARS", (Lars, LassoLars, LassoLarsIC))
 @pytest.mark.parametrize("x_data_type, y_data_type, expected_type", (
     (np.float32, np.float32, np.float32),

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -811,7 +811,8 @@ def test_lars_dtype_match(LARS, has_coef_path, args,
                           # max_iter=5 is for avoiding ConvergenceWarning
                           (LassoLarsCV, True, {"max_iter": 5})))
 def test_lars_numeric_consistency(LARS, has_coef_path, args):
-    atol = 1e-6
+    rtol = 1e-5
+    atol = 1e-5
 
     rng = np.random.RandomState(0)
     X_64 = rng.rand(6, 6)
@@ -821,7 +822,9 @@ def test_lars_numeric_consistency(LARS, has_coef_path, args):
     model_32 = LARS(**args).fit(X_64.astype(np.float32),
                                 y_64.astype(np.float32))
 
-    assert_allclose(model_64.coef_, model_32.coef_, atol=atol)
+    assert_allclose(model_64.coef_, model_32.coef_, rtol=rtol, atol=atol)
     if has_coef_path:
-        assert_allclose(model_64.coef_path_, model_32.coef_path_, atol=atol)
-    assert_allclose(model_64.intercept_, model_32.intercept_, atol=atol)
+        assert_allclose(model_64.coef_path_, model_32.coef_path_,
+                        rtol=rtol, atol=atol)
+    assert_allclose(model_64.intercept_, model_32.intercept_,
+                    rtol=rtol, atol=atol)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -796,3 +796,18 @@ def test_lars_dtype_match(LARS, x_data_type, y_data_type, expected_type):
         for coef in model.coef_path_:
             assert coef.dtype == expected_type
     assert model.intercept_.dtype == expected_type
+
+
+@pytest.mark.parametrize("LARS", (Lars, LassoLars, LassoLarsIC))
+def test_lars_numeric_consistency(LARS):
+    rng = np.random.RandomState(0)
+    X_64 = rng.rand(6, 6)
+    y_64 = rng.rand(6)
+
+    model_64 = LARS().fit(X_64, y_64)
+    model_32 = LARS().fit(X_64.astype(np.float32), y_64.astype(np.float32))
+
+    assert_array_almost_equal(model_64.coef_, model_32.coef_)
+    if hasattr(model_64, "coef_path_"):
+        assert_array_almost_equal(model_64.coef_path_, model_32.coef_path_)
+    assert_array_almost_equal(model_64.intercept_, model_32.intercept_)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -786,22 +786,19 @@ def test_copy_X_with_auto_gram():
                           (LarsCV, True, {}),
                           # max_iter=5 is for avoiding ConvergenceWarning
                           (LassoLarsCV, True, {"max_iter": 5})))
-@pytest.mark.parametrize("data_type, expected_type", (
-    (np.float32, np.float32),
-    (np.float64, np.float64)))
-def test_lars_dtype_match(LARS, has_coef_path, args,
-                          data_type, expected_type):
+@pytest.mark.parametrize("dtype", (np.float32, np.float64))
+def test_lars_dtype_match(LARS, has_coef_path, args, dtype):
     # The test ensures that the fit method preserves input dtype
     rng = np.random.RandomState(0)
-    X = rng.rand(6, 6).astype(data_type)
-    y = rng.rand(6).astype(data_type)
+    X = rng.rand(6, 6).astype(dtype)
+    y = rng.rand(6).astype(dtype)
 
     model = LARS(**args)
     model.fit(X, y)
-    assert model.coef_.dtype == expected_type
+    assert model.coef_.dtype == dtype
     if has_coef_path:
-        assert model.coef_path_.dtype == expected_type
-    assert model.intercept_.dtype == expected_type
+        assert model.coef_path_.dtype == dtype
+    assert model.intercept_.dtype == dtype
 
 
 @pytest.mark.parametrize("LARS, has_coef_path, args",

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -779,11 +779,14 @@ def test_copy_X_with_auto_gram():
     assert_allclose(X, X_before)
 
 
-@pytest.mark.parametrize("LARS", (Lars, LassoLars, LassoLarsIC))
+@pytest.mark.parametrize("LARS, has_coef_path", ((Lars, True),
+                                                 (LassoLars, True),
+                                                 (LassoLarsIC, False)))
 @pytest.mark.parametrize("x_data_type, y_data_type, expected_type", (
     (np.float32, np.float32, np.float32),
     (np.float64, np.float64, np.float64)))
-def test_lars_dtype_match(LARS, x_data_type, y_data_type, expected_type):
+def test_lars_dtype_match(LARS, has_coef_path,
+                          x_data_type, y_data_type, expected_type):
     rng = np.random.RandomState(0)
     X = rng.rand(6, 6).astype(x_data_type)
     y = rng.rand(6).astype(y_data_type)
@@ -791,15 +794,15 @@ def test_lars_dtype_match(LARS, x_data_type, y_data_type, expected_type):
     model = LARS()
     model.fit(X, y)
     assert model.coef_.dtype == expected_type
-    if hasattr(model, "coef_path_"):
-        # coef_path_ can be list of array
-        for coef in model.coef_path_:
-            assert coef.dtype == expected_type
+    if has_coef_path:
+        assert model.coef_path_.dtype == expected_type
     assert model.intercept_.dtype == expected_type
 
 
-@pytest.mark.parametrize("LARS", (Lars, LassoLars, LassoLarsIC))
-def test_lars_numeric_consistency(LARS):
+@pytest.mark.parametrize("LARS, has_coef_path", ((Lars, True),
+                                                 (LassoLars, True),
+                                                 (LassoLarsIC, False)))
+def test_lars_numeric_consistency(LARS, has_coef_path):
     rng = np.random.RandomState(0)
     X_64 = rng.rand(6, 6)
     y_64 = rng.rand(6)
@@ -808,6 +811,6 @@ def test_lars_numeric_consistency(LARS):
     model_32 = LARS().fit(X_64.astype(np.float32), y_64.astype(np.float32))
 
     assert_array_almost_equal(model_64.coef_, model_32.coef_)
-    if hasattr(model_64, "coef_path_"):
+    if has_coef_path:
         assert_array_almost_equal(model_64.coef_path_, model_32.coef_path_)
     assert_array_almost_equal(model_64.intercept_, model_32.intercept_)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -778,19 +778,20 @@ def test_copy_X_with_auto_gram():
     # X did not change
     assert_allclose(X, X_before)
 
-
+@pytest.mark.parametrize("LARS", (Lars, LassoLars, LassoLarsIC))
 @pytest.mark.parametrize("x_data_type, y_data_type, expected_type", (
     (np.float32, np.float32, np.float32),
     (np.float64, np.float64, np.float64)))
-def test_lars_dtype_match(x_data_type, y_data_type, expected_type):
+def test_lars_dtype_match(LARS, x_data_type, y_data_type, expected_type):
     rng = np.random.RandomState(0)
     X = rng.rand(6, 6).astype(x_data_type)
     y = rng.rand(6).astype(y_data_type)
 
-    model = Lars()
+    model = LARS()
     model.fit(X, y)
     assert model.coef_.dtype == expected_type
-    # coef_path_ can be list of array
-    for coef in model.coef_path_:
-        assert coef.dtype == expected_type
+    if hasattr(model, "coef_path_"):
+        # coef_path_ can be list of array
+        for coef in model.coef_path_:
+            assert coef.dtype == expected_type
     assert model.intercept_.dtype == expected_type

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -791,6 +791,7 @@ def test_copy_X_with_auto_gram():
     (np.float64, np.float64, np.float64)))
 def test_lars_dtype_match(LARS, has_coef_path, args,
                           x_data_type, y_data_type, expected_type):
+    # The test ensures that the fit method preserves input dtype
     rng = np.random.RandomState(0)
     X = rng.rand(6, 6).astype(x_data_type)
     y = rng.rand(6).astype(y_data_type)
@@ -811,6 +812,8 @@ def test_lars_dtype_match(LARS, has_coef_path, args,
                           # max_iter=5 is for avoiding ConvergenceWarning
                           (LassoLarsCV, True, {"max_iter": 5})))
 def test_lars_numeric_consistency(LARS, has_coef_path, args):
+    # The test ensures numerical consistency between trained coefficients
+    # of float32 and float64.
     rtol = 1e-5
     atol = 1e-5
 

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -778,13 +778,19 @@ def test_copy_X_with_auto_gram():
     # X did not change
     assert_allclose(X, X_before)
 
-def test_lars_dtype_match():
-    rng = np.random.RandomState(0)
-    X = rng.rand(6, 6).astype(np.float32)
-    Y = rng.rand(6).astype(np.float32)
 
-    model = Lars(n_nonzero_coefs=1)
-    model.fit(X,Y)
-    assert model.coef_.dtype == np.float32
-    assert model.coef_path_.dtype == np.float32
-    assert model.intercept_.dtype == np.float32
+@pytest.mark.parametrize("x_data_type, y_data_type, expected_type", (
+    (np.float32, np.float32, np.float32),
+    (np.float64, np.float64, np.float64)))
+def test_lars_dtype_match(x_data_type, y_data_type, expected_type):
+    rng = np.random.RandomState(0)
+    X = rng.rand(6, 6).astype(x_data_type)
+    y = rng.rand(6).astype(y_data_type)
+
+    model = Lars()
+    model.fit(X, y)
+    assert model.coef_.dtype == expected_type
+    # coef_path_ can be list of array
+    for coef in model.coef_path_:
+        assert coef.dtype == expected_type
+    assert model.intercept_.dtype == expected_type

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -14,7 +14,7 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn import linear_model, datasets
 from sklearn.linear_model._least_angle import _lars_path_residues
 from sklearn.linear_model import LassoLarsIC, lars_path
-from sklearn.linear_model import Lars, LassoLars
+from sklearn.linear_model import Lars, LassoLars, LarsCV, LassoLarsCV
 
 # TODO: use another dataset that has multiple drops
 diabetes = datasets.load_diabetes()
@@ -779,19 +779,23 @@ def test_copy_X_with_auto_gram():
     assert_allclose(X, X_before)
 
 
-@pytest.mark.parametrize("LARS, has_coef_path", ((Lars, True),
-                                                 (LassoLars, True),
-                                                 (LassoLarsIC, False)))
+@pytest.mark.parametrize("LARS, has_coef_path, args",
+                         ((Lars, True, {}),
+                          (LassoLars, True, {}),
+                          (LassoLarsIC, False, {}),
+                          (LarsCV, True, {}),
+                          # max_iter=5 is for avoiding ConvergenceWarning
+                          (LassoLarsCV, True, {"max_iter": 5})))
 @pytest.mark.parametrize("x_data_type, y_data_type, expected_type", (
     (np.float32, np.float32, np.float32),
     (np.float64, np.float64, np.float64)))
-def test_lars_dtype_match(LARS, has_coef_path,
+def test_lars_dtype_match(LARS, has_coef_path, args,
                           x_data_type, y_data_type, expected_type):
     rng = np.random.RandomState(0)
     X = rng.rand(6, 6).astype(x_data_type)
     y = rng.rand(6).astype(y_data_type)
 
-    model = LARS()
+    model = LARS(**args)
     model.fit(X, y)
     assert model.coef_.dtype == expected_type
     if has_coef_path:
@@ -799,16 +803,21 @@ def test_lars_dtype_match(LARS, has_coef_path,
     assert model.intercept_.dtype == expected_type
 
 
-@pytest.mark.parametrize("LARS, has_coef_path", ((Lars, True),
-                                                 (LassoLars, True),
-                                                 (LassoLarsIC, False)))
-def test_lars_numeric_consistency(LARS, has_coef_path):
+@pytest.mark.parametrize("LARS, has_coef_path, args",
+                         ((Lars, True, {}),
+                          (LassoLars, True, {}),
+                          (LassoLarsIC, False, {}),
+                          (LarsCV, True, {}),
+                          # max_iter=5 is for avoiding ConvergenceWarning
+                          (LassoLarsCV, True, {"max_iter": 5})))
+def test_lars_numeric_consistency(LARS, has_coef_path, args):
     rng = np.random.RandomState(0)
     X_64 = rng.rand(6, 6)
     y_64 = rng.rand(6)
 
-    model_64 = LARS().fit(X_64, y_64)
-    model_32 = LARS().fit(X_64.astype(np.float32), y_64.astype(np.float32))
+    model_64 = LARS(**args).fit(X_64, y_64)
+    model_32 = LARS(**args).fit(X_64.astype(np.float32),
+                                y_64.astype(np.float32))
 
     assert_array_almost_equal(model_64.coef_, model_32.coef_)
     if has_coef_path:

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -178,10 +178,18 @@ def spectral_embedding(adjacency, *, n_components=8, eigen_solver=None,
         used.
 
     random_state : int, RandomState instance or None, default=None
-        Determines the random number generator used for the initialization of
-        the lobpcg eigenvectors decomposition when ``solver`` == 'amg'. Pass
-        an int for reproducible results across multiple function calls.
-        See :term: `Glossary <random_state>`.
+        A pseudo random number generator used for the initialization
+        of the lobpcg eigen vectors decomposition when `eigen_solver ==
+        'amg'`, and for the K-Means initialization. Use an int to make
+        the results deterministic across calls (See
+        :term:`Glossary <random_state>`).
+
+        .. note::
+            When using `eigen_solver == 'amg'`,
+            it is necessary to also fix the global numpy seed with
+            `np.random.seed(int)` to get deterministic results. See
+            https://github.com/pyamg/pyamg/issues/139 for further
+            information.
 
     eigen_tol : float, default=0.0
         Stopping criterion for eigendecomposition of the Laplacian matrix
@@ -396,10 +404,18 @@ class SpectralEmbedding(BaseEstimator):
         1/n_features.
 
     random_state : int, RandomState instance or None, default=None
-        Determines the random number generator used for the initialization of
-        the lobpcg eigenvectors when ``solver`` == 'amg'.  Pass an int for
-        reproducible results across multiple function calls.
-        See :term: `Glossary <random_state>`.
+        A pseudo random number generator used for the initialization
+        of the lobpcg eigen vectors decomposition when `eigen_solver ==
+        'amg'`, and for the K-Means initialization. Use an int to make
+        the results deterministic across calls (See
+        :term:`Glossary <random_state>`).
+
+        .. note::
+            When using `eigen_solver == 'amg'`,
+            it is necessary to also fix the global numpy seed with
+            `np.random.seed(int)` to get deterministic results. See
+            https://github.com/pyamg/pyamg/issues/139 for further
+            information.
 
     eigen_solver : {'arpack', 'lobpcg', 'amg'}, default=None
         The eigenvalue decomposition strategy to use. AMG requires pyamg

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1468,25 +1468,17 @@ def _precompute_metric_params(X, Y, metric=None, **kwds):
         if X is Y:
             V = np.var(X, axis=0, ddof=1, dtype=dtype)
         else:
-            warnings.warn(
-                "from version 1.0 (renaming of 0.25), pairwise_distances for "
-                "metric='seuclidean' will require V to be specified if Y is "
-                "passed.",
-                FutureWarning
-            )
-            V = np.var(np.vstack([X, Y]), axis=0, ddof=1, dtype=dtype)
+            raise ValueError(
+                  "The 'V' parameter is required for the seuclidean metric "
+                  "when Y is passed.")
         return {'V': V}
     if metric == "mahalanobis" and 'VI' not in kwds:
         if X is Y:
             VI = np.linalg.inv(np.cov(X.T)).T
         else:
-            warnings.warn(
-                "from version 1.0 (renaming of 0.25), pairwise_distances for "
-                "metric='mahalanobis' will require VI to be specified if Y "
-                "is passed.",
-                FutureWarning
-            )
-            VI = np.linalg.inv(np.cov(np.vstack([X, Y]).T)).T
+            raise ValueError(
+                  "The 'VI' parameter is required for the mahalanobis metric "
+                  "when Y is passed.")
         return {'VI': VI}
     return {}
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -821,7 +821,7 @@ def test_regression_thresholded_inf_nan_input(metric, y_true, y_score):
     # Add an additional case for classification only
     # non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/6809
-    [([np.nan, 1, 2], [1, 2, 3])]
+    [([np.nan, 1, 2], [1, 2, 3])]  # type: ignore
 )
 def test_classification_inf_nan_input(metric, y_true, y_score):
     """check that classification metrics raise a message mentioning the

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -30,6 +30,8 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
     For example, if an input sample is two dimensional and of the form
     [a, b], the degree-2 polynomial features are [1, a, b, a^2, ab, b^2].
 
+    Read more in the :ref:`User Guide <polynomial_features>`.
+
     Parameters
     ----------
     degree : int, default=2


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
This PR is part of  #11000 .

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR makes trained coefficients of Least Angle Regression to be numpy.float32 if input data is numpy.float32.

Conventionally when you pass numpy.float32 to Least Angle Regression, trained coefficients turn to be numpy.float64. This is inconsistent.

#### Any other comments?

We can pass training data x and target y to Least Angle Regressor. Test cases in this PR are that both are numpy.flaot32 or numpy.float64, because it is unclear which type is appropriate when x's type is different from y's type. This is the same with #13243 .

Further test cases may be required because this PR does not cover argument variations.

I used #13303 and #13243 as references to make this.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
